### PR TITLE
feat: add datawaves abi provider

### DIFF
--- a/datawaves/__init__.py
+++ b/datawaves/__init__.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import
 
 from datawaves.ethereum.condition import new_trace_conditions, new_log_conditions
+from datawaves.ethereum.providers import DatawavesABIProvider
 
 __all__ = [
     new_trace_conditions,
-    new_log_conditions
+    new_log_conditions,
+    DatawavesABIProvider
 ]

--- a/datawaves/ethereum/providers.py
+++ b/datawaves/ethereum/providers.py
@@ -1,0 +1,14 @@
+import logging
+import requests
+
+from spark3.providers import IContractABIProvider
+
+class DatawavesABIProvider(IContractABIProvider):
+    logger = logging.getLogger("datawaves.DatawavesProvider")
+
+    def get_contract_abi(self, contract_address: str) -> str:
+        r = requests.get("http://abi-cache.tellery-prod:3000/api/getabi", params={
+            'address': contract_address
+        })
+        r.raise_for_status()
+        return r.text

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ long_description = read('README.md') if os.path.isfile("README.md") else ""
 
 setup(
     name='blockchain-spark',
-    version='0.4.0',
+    version='0.4.1',
     author='songv',
     author_email='songwei@iftech.io',
     description='Spark extension utils for blockchain',

--- a/spark3/__init__.py
+++ b/spark3/__init__.py
@@ -1,12 +1,11 @@
 from __future__ import absolute_import
 
 from spark3.main import Spark3, Transformer
-from spark3.providers import IContractABIProvider, EtherscanABIProvider, DatawavesABIProvider
+from spark3.providers import IContractABIProvider, EtherscanABIProvider
 
 __all__ = [
     Spark3,
     Transformer,
     IContractABIProvider,
     EtherscanABIProvider,
-    DatawavesABIProvider,
 ]

--- a/spark3/__init__.py
+++ b/spark3/__init__.py
@@ -1,8 +1,12 @@
 from __future__ import absolute_import
 
 from spark3.main import Spark3, Transformer
+from spark3.providers import IContractABIProvider, EtherscanABIProvider, DatawavesABIProvider
 
 __all__ = [
     Spark3,
-    Transformer
+    Transformer,
+    IContractABIProvider,
+    EtherscanABIProvider,
+    DatawavesABIProvider,
 ]

--- a/spark3/ethereum/contract.py
+++ b/spark3/ethereum/contract.py
@@ -28,7 +28,8 @@ class Contract:
         self._abi_provider = abi_provider
         self._abi_json = abi
 
-        if self._abi_provider is not None:
+        if self._abi_provider is not None and self._abi_json is None:
+            # Getting abi json from abi provider only if abi is not provided
             self._abi_json = self._abi_provider.get_contract_abi(self.address)
 
         if self._abi_json is None:

--- a/spark3/main.py
+++ b/spark3/main.py
@@ -7,13 +7,12 @@ from pyspark.sql.types import StructType
 from spark3.ethereum.condition import Conditions
 from spark3.ethereum.contract import Contract
 from spark3.exceptions import ColumnNotFoundInDataFrame
-from spark3.providers import IContractABIProvider, EtherscanABIProvider, DatawavesABIProvider
+from spark3.providers import IContractABIProvider, EtherscanABIProvider
 from spark3.utils.df_util import contains_column
 
 
 class Spark3:
     EtherscanABIProvider = EtherscanABIProvider
-    DatawavesABIProvider = DatawavesABIProvider
 
     def __init__(self, spark: SparkSession,
                  trace: Optional[DataFrame] = None,

--- a/spark3/main.py
+++ b/spark3/main.py
@@ -7,12 +7,13 @@ from pyspark.sql.types import StructType
 from spark3.ethereum.condition import Conditions
 from spark3.ethereum.contract import Contract
 from spark3.exceptions import ColumnNotFoundInDataFrame
-from spark3.providers import IContractABIProvider, EtherscanABIProvider
+from spark3.providers import IContractABIProvider, EtherscanABIProvider, DatawavesABIProvider
 from spark3.utils.df_util import contains_column
 
 
 class Spark3:
     EtherscanABIProvider = EtherscanABIProvider
+    DatawavesABIProvider = DatawavesABIProvider
 
     def __init__(self, spark: SparkSession,
                  trace: Optional[DataFrame] = None,

--- a/spark3/main.py
+++ b/spark3/main.py
@@ -18,7 +18,8 @@ class Spark3:
                  trace: Optional[DataFrame] = None,
                  log: Optional[DataFrame] = None,
                  trace_conditions: Optional[Conditions] = None,
-                 log_conditions: Optional[Conditions] = None):
+                 log_conditions: Optional[Conditions] = None,
+                 default_abi_provider: Optional[IContractABIProvider] = None):
         """
         :param spark: :class:`SparkSession`
         :param trace: :class:`DataFrame` to store original data to decode contract functions
@@ -32,6 +33,7 @@ class Spark3:
         self.log_df = log
         self.trace_conditions = trace_conditions
         self.log_conditions = log_conditions
+        self.default_abi_provider = default_abi_provider
         self._transformer = Transformer()
 
     def contract(self, address: str,
@@ -55,7 +57,7 @@ class Spark3:
         >>>
         >>> contract = s3.contract(address=..., abi_provider=...)
         """
-        return Contract(self, address, abi, abi_provider)
+        return Contract(self, address, abi, abi_provider if abi_provider is not None else self.default_abi_provider)
 
     def transformer(self):
         return self._transformer

--- a/spark3/providers.py
+++ b/spark3/providers.py
@@ -33,13 +33,3 @@ class EtherscanABIProvider(IContractABIProvider):
             self.logger.error("Failed to get contract abi: %s:%s", data['status'], data['message'])
             raise FailToGetEtherscanABI(data['message'])
         return data['result']
-
-class DatawavesABIProvider(IContractABIProvider):
-    logger = logging.getLogger("spark3.providers.DatawavesProvider")
-
-    def get_contract_abi(self, contract_address: str) -> str:
-        r = requests.get("http://abi-cache.tellery-prod:3000/api/getabi", params={
-            'address': contract_address
-        })
-        r.raise_for_status()
-        return r.text

--- a/spark3/providers.py
+++ b/spark3/providers.py
@@ -14,7 +14,7 @@ class IContractABIProvider(metaclass=ABCMeta):
 
 
 class EtherscanABIProvider(IContractABIProvider):
-    logger = logging.getLogger("contract.EtherscanProvider")
+    logger = logging.getLogger("spark3.providers.EtherscanProvider")
 
     def __init__(self, apikey: Optional[str] = None):
         if apikey is None:
@@ -33,3 +33,13 @@ class EtherscanABIProvider(IContractABIProvider):
             self.logger.error("Failed to get contract abi: %s:%s", data['status'], data['message'])
             raise FailToGetEtherscanABI(data['message'])
         return data['result']
+
+class DatawavesABIProvider(IContractABIProvider):
+    logger = logging.getLogger("spark3.providers.DatawavesProvider")
+
+    def get_contract_abi(self, contract_address: str) -> str:
+        r = requests.get("http://abi-cache.tellery-prod:3000/api/getabi", params={
+            'address': contract_address
+        })
+        r.raise_for_status()
+        return r.text


### PR DESCRIPTION
See [here](https://app.datawaves.xyz/notebook/1bb337e1-b592-474c-a1bb-898ba923c8da)

Should this class be added into `datawaves` package or `spark3`?

Btw, I'm wondering if the deserialization of ABI should be done in initializting contract (`normalize_abi`) or in ABIProvider ? since actually we stored ABI as `jsonb` in our db