### PR TITLE
fix: Java BigInt and BigDecimal can't be store in the Hive.

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>io.iftech</groupId>
   <artifactId>blockchain-spark</artifactId>
-  <version>0.5.2</version>
+  <version>0.5.3</version>
   <name>blockchain-spark</name>
 
   <properties>

--- a/java/src/main/java/io/iftech/sparkudf/converter/HiveConverter.java
+++ b/java/src/main/java/io/iftech/sparkudf/converter/HiveConverter.java
@@ -6,13 +6,9 @@ import com.esaulpaugh.headlong.abi.TupleType;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.List;
-import org.apache.hadoop.hive.common.type.HiveDecimal;
-import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.hadoop.io.BooleanWritable;
 import org.apache.hadoop.io.ByteWritable;
 import org.apache.hadoop.io.BytesWritable;
-import org.apache.hadoop.io.IntWritable;
-import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 
 public class HiveConverter extends Converter<List<Object>> {
@@ -41,24 +37,27 @@ public class HiveConverter extends Converter<List<Object>> {
         return new Text(val);
     }
 
+    // In Hive, the biggest value of the BIGINT is 9,223,372,036,854,775,807, the biggest precision
+    // of the decimal is 38, so there is no data type that can store the 256bit number. For better
+    // compatibility, we transform all number type to string type.
     @Override
     public Object convertInt(Integer val) {
-        return new IntWritable(val);
+        return new Text(val.toString());
     }
 
     @Override
     public Object convertLong(Long val) {
-        return new LongWritable(val);
+        return new Text(val.toString());
     }
 
     @Override
     public Object convertBigInteger(BigInteger val) {
-        return new HiveDecimalWritable(HiveDecimal.create(val));
+        return new Text(val.toString());
     }
 
     @Override
     public Object convertBigDecimal(BigDecimal val) {
-        return new HiveDecimalWritable(HiveDecimal.create(val));
+        return new Text(val.toString());
     }
 
     @Override

--- a/java/src/test/java/io/iftech/sparkudf/converter/HiveConverterTest.java
+++ b/java/src/test/java/io/iftech/sparkudf/converter/HiveConverterTest.java
@@ -13,11 +13,8 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
-import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.hadoop.io.BooleanWritable;
 import org.apache.hadoop.io.BytesWritable;
-import org.apache.hadoop.io.IntWritable;
-import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 import org.junit.Test;
 
@@ -63,34 +60,34 @@ public class HiveConverterTest {
 
         assertTrue(result.get(0) instanceof Text);
         assertEquals("0x7be8076f4ea4a4ad08075c2508e481d6c946d12b", result.get(0).toString());
-        assertTrue(result.get(1) instanceof IntWritable);
+        assertTrue(result.get(1) instanceof Text);
         assertEquals(-100, Integer.parseInt(result.get(1).toString()));
-        assertTrue(result.get(2) instanceof IntWritable);
+        assertTrue(result.get(2) instanceof Text);
         assertEquals(-3000, Integer.parseInt(result.get(2).toString()));
-        assertTrue(result.get(3) instanceof IntWritable);
+        assertTrue(result.get(3) instanceof Text);
         assertEquals(-2000000000, Integer.parseInt(result.get(3).toString()));
-        assertTrue(result.get(4) instanceof LongWritable);
+        assertTrue(result.get(4) instanceof Text);
         assertEquals(-8000000000L, Long.parseLong(result.get(4).toString()));
-        assertTrue(result.get(5) instanceof IntWritable);
+        assertTrue(result.get(5) instanceof Text);
         assertEquals(100, Integer.parseInt(result.get(5).toString()));
-        assertTrue(result.get(6) instanceof IntWritable);
+        assertTrue(result.get(6) instanceof Text);
         assertEquals(30000, Integer.parseInt(result.get(6).toString()));
-        assertTrue(result.get(7) instanceof LongWritable);
+        assertTrue(result.get(7) instanceof Text);
         assertEquals(2000000000L, Long.parseLong(result.get(7).toString()));
-        assertTrue(result.get(8) instanceof HiveDecimalWritable);
+        assertTrue(result.get(8) instanceof Text);
         assertEquals(8000000000L, Long.parseLong(result.get(8).toString()));
         assertTrue(result.get(9) instanceof BooleanWritable);
         assertTrue(Boolean.parseBoolean(result.get(9).toString()));
-        assertTrue(result.get(10) instanceof HiveDecimalWritable);
+        assertTrue(result.get(10) instanceof Text);
         assertEquals(-10000.2, Double.parseDouble(result.get(10).toString()), 0.0000001);
-        assertTrue(result.get(11) instanceof HiveDecimalWritable);
+        assertTrue(result.get(11) instanceof Text);
         assertEquals(10000.2, Double.parseDouble(result.get(11).toString()), 0.0000001);
         assertTrue(result.get(12) instanceof BytesWritable);
         assertTrue(result.get(13) instanceof BytesWritable);
         assertTrue(result.get(14) instanceof Text);
-        assertTrue(((List<Object>) result.get(15)).get(0) instanceof IntWritable);
+        assertTrue(((List<Object>) result.get(15)).get(0) instanceof Text);
         assertTrue(((List<Object>) result.get(17)).get(0) instanceof BooleanWritable);
-        assertTrue(((LinkedList<Object>) result.get(18)).get(0) instanceof HiveDecimalWritable);
+        assertTrue(((LinkedList<Object>) result.get(18)).get(0) instanceof Text);
         assertTrue(((LinkedList<Object>) result.get(18)).get(1) instanceof Text);
     }
 }

--- a/java/src/test/java/io/iftech/sparkudf/hive/DecodeContractEventHiveUDFTest.java
+++ b/java/src/test/java/io/iftech/sparkudf/hive/DecodeContractEventHiveUDFTest.java
@@ -8,12 +8,10 @@ import com.google.gson.GsonBuilder;
 import io.iftech.sparkudf.Mocks.ContractEvent;
 import io.iftech.sparkudf.Mocks.EventField;
 import io.iftech.sparkudf.converter.Converter;
-import java.math.BigDecimal;
 import java.util.List;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredJavaObject;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredObject;
-import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.hadoop.hive.serde2.objectinspector.ListObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
@@ -76,8 +74,6 @@ public class DecodeContractEventHiveUDFTest {
 
         assertEquals("0xb3f923eabaf178fc1bd8e13902fc5c61d3ddef5b", resultData.get(0).toString());
         assertEquals("0x28c6c06298d514db089934071355e5743bf21d60", resultData.get(1).toString());
-        assertEquals(0, ((HiveDecimalWritable) resultData.get(2))
-            .getHiveDecimal().bigDecimalValue()
-            .compareTo(new BigDecimal("279283000000000000000000")));
+        assertEquals("279283000000000000000000", resultData.get(2).toString());
     }
 }

--- a/java/src/test/java/io/iftech/sparkudf/hive/DecodeContractFunctionHiveUDFTest.java
+++ b/java/src/test/java/io/iftech/sparkudf/hive/DecodeContractFunctionHiveUDFTest.java
@@ -12,21 +12,19 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import io.iftech.sparkudf.Mocks.ContractFunction;
 import io.iftech.sparkudf.Mocks.FunctionField;
-import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.List;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredJavaObject;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredObject;
-import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.StandardStructObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.BinaryObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
 import org.apache.hadoop.io.BooleanWritable;
 import org.apache.hadoop.io.BytesWritable;
-import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.Text;
 import org.junit.Test;
 
 @SuppressWarnings("unchecked")
@@ -99,25 +97,22 @@ public class DecodeContractFunctionHiveUDFTest {
         List<Object> resultData = inputOI.getStructFieldsDataAsList(inputData);
 
         assertEquals("This is a string", resultData.get(0).toString());
-        assertEquals(0, ((HiveDecimalWritable) resultData.get(1)).getHiveDecimal().bigDecimalValue()
-            .compareTo(new BigDecimal("100000000000")));
+        assertEquals(new Text("100000000000"), resultData.get(1));
         assertEquals("0x7be8076f4ea4a4ad08075c2508e481d6c946d12b", resultData.get(2).toString());
         assertArrayEquals(new byte[]{0, 1, 1, 0}, ((BytesWritable) resultData.get(3)).getBytes());
         assertTrue(((BooleanWritable) resultData.get(4)).get());
         assertArrayEquals(new byte[]{9, 9}, ((BytesWritable) resultData.get(5)).getBytes());
 
         assertEquals(2, ((List<Object>) resultData.get(6)).size());
-        assertEquals(17, ((IntWritable) ((List<Object>) resultData.get(6)).get(0)).get());
-        assertEquals(19, ((IntWritable) ((List<Object>) resultData.get(6)).get(1)).get());
+        assertEquals(new Text("17"), ((List<Object>) resultData.get(6)).get(0));
+        assertEquals(new Text("19"), ((List<Object>) resultData.get(6)).get(1));
 
         assertEquals(1, ((List<Object>) resultData.get(7)).size());
         assertEquals("0x7be8076f4ea4a4ad08075c2508e481d6c946d12b",
             ((List<Object>) resultData.get(7)).get(0).toString());
 
         assertEquals(1, ((List<Object>) resultData.get(8)).size());
-        assertEquals(0,
-            ((HiveDecimalWritable) ((List<Object>) resultData.get(8)).get(
-                0)).getHiveDecimal().bigDecimalValue().compareTo(new BigDecimal("400000000000")));
+        assertEquals(new Text("400000000000"), ((List<Object>) resultData.get(8)).get(0));
 
         assertEquals(1, ((List<Object>) resultData.get(9)).size());
         assertArrayEquals(new byte[]{0, 1, 1, 0},
@@ -132,8 +127,6 @@ public class DecodeContractFunctionHiveUDFTest {
         List<Object> testInnerTupleObjects = testInnerTupleOI.getStructFieldsDataAsList(
             dataObjects.get(0));
 
-        assertEquals(0,
-            ((HiveDecimalWritable) testInnerTupleObjects.get(0)).getHiveDecimal().bigDecimalValue()
-                .compareTo(new BigDecimal("300000000000")));
+        assertEquals(new Text("300000000000"), testInnerTupleObjects.get(0));
     }
 }

--- a/java/src/test/java/io/iftech/sparkudf/hive/OpenseaWyvernExchangeV2AtomicMatchTest.java
+++ b/java/src/test/java/io/iftech/sparkudf/hive/OpenseaWyvernExchangeV2AtomicMatchTest.java
@@ -1,6 +1,7 @@
 package io.iftech.sparkudf.hive;
 
 import static io.iftech.sparkudf.TestUtils.hexStringToByteArray;
+import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
@@ -15,6 +16,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.StandardStructObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.BinaryObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.io.Text;
 import org.junit.Test;
 
 @SuppressWarnings("unchecked")
@@ -65,10 +67,27 @@ public class OpenseaWyvernExchangeV2AtomicMatchTest {
         // Parse output data by output inspector and check it
         StandardStructObjectInspector inputOI = (StandardStructObjectInspector) resultOI.getStructFieldRef(
             "input").getFieldObjectInspector();
-        // TODO handle BigInt in Hive UDF
-//        List<Object> inputData = (List<Object>) resultOI.getStructFieldData(result,
-//            resultOI.getStructFieldRef("input"));
-//        List<Object> resultData = inputOI.getStructFieldsDataAsList(inputData);
+        List<Object> inputData = (List<Object>) resultOI.getStructFieldData(result,
+            resultOI.getStructFieldRef("input"));
+        List<Object> resultData = inputOI.getStructFieldsDataAsList(inputData);
 
+        List<Object> addrs = (List<Object>) resultData.get(0);
+        assertEquals(14, addrs.size());
+        assertEquals("0x7f268357a8c2552623316e2562d90e642bb538e5", addrs.get(0).toString());
+        assertEquals("0x66c7f46b0cb2482119c33010f89ebfd3591f936f", addrs.get(1).toString());
+        assertEquals("0x0000000000000000000000000000000000000000", addrs.get(13).toString());
+
+        List<Object> uints = (List<Object>) resultData.get(1);
+        assertEquals(18, uints.size());
+        assertEquals(new Text("750"), uints.get(0));
+        assertEquals(new Text("7600000000000000000"), uints.get(4));
+        assertEquals(
+            new Text(
+                "12112854536475579701709856639006968439346510087985402025553784139104925563853"),
+            uints.get(8));
+        assertEquals(
+            new Text(
+                "70816310222907633346803407554718755161164435004871826408466484445498409136346"),
+            uints.get(17));
     }
 }


### PR DESCRIPTION
Transform all number type to string type in the Hive UDF.